### PR TITLE
mebo4-report-bucket-policy-update

### DIFF
--- a/examples/source/aws-backups.tf
+++ b/examples/source/aws-backups.tf
@@ -44,6 +44,29 @@ resource "aws_s3_bucket_acl" "backup_reports" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_policy" "backup_reports_policy" {
+  bucket = aws_s3_bucket.backup_reports.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::${local.source_account_id}:role/aws-service-role/reports.backup.amazonaws.com/AWSServiceRoleForBackupReports"
+        },
+        Action = "s3:PutObject",
+        Resource = "${aws_s3_bucket.backup_reports.arn}/*",
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      }
+    ]
+  })
+}
+
+
 # We need a key for the SNS topic that will be used for notifications from AWS Backup. This key
 # will be used to encrypt the messages sent to the topic before they are sent to the subscribers,
 # but isn't needed by the recipients of the messages.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Currently the backup reports generated do not have access to be written to the s3 reports bucket. The AWSServiceRoleForBackupReports needs permissions to access the report bucket.

## Context

This is change is needed so that the reports can be stored and accessed in the s3 report bucket.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
