### PR TITLE
Fix for incorrect local variable name

### DIFF
--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -2,6 +2,6 @@ locals {
   resource_name_prefix                      = "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup"
   selection_tag_value_null_checked          = (var.backup_plan_config.selection_tag_value == null) ? "True" : var.backup_plan_config.selection_tag_value
   selection_tag_value_dynamodb_null_checked = (var.backup_plan_config_dynamodb.selection_tag_value == null) ? "True" : var.backup_plan_config_dynamodb.selection_tag_value
-  selection_tags_null_checked               = (var.backup_plan_config.selection_tags == null) ? [{ "key" : "${var.backup_plan_config.selection_tag}", "value" : "${local.selection_tag_value_null_checked}" }] : var.backup_plan_config.selection_tags
-  selection_tags_dynamodb_null_checked      = (var.backup_plan_config_dynamodb.selection_tags == null) ? [{ "key" : "${var.backup_plan_config_dynamodb.selection_tag}", "value" : "${local.selection_tag_value_dynamodb_null_checked}" }] : var.backup_plan_config_dynamodb.selection_tags
+  selection_tags_null_checked               = (var.backup_plan_config.selection_tags == null) ? [{ "key" : var.backup_plan_config.selection_tag, "value" : local.selection_tag_value_null_checked }] : var.backup_plan_config.selection_tags
+  selection_tags_dynamodb_null_checked      = (var.backup_plan_config_dynamodb.selection_tags == null) ? [{ "key" : var.backup_plan_config_dynamodb.selection_tag, "value" : local.selection_tag_value_dynamodb_null_checked }] : var.backup_plan_config_dynamodb.selection_tags
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Fix for the error 
 A local value with the name "selection_tags_null_checked" has not been declared.

## Context

This is a bug fix for an error in merge request 33, the module will throw an error that the local value with the name selection_tags_null_checked has not been declared due an a refactoring error. This change corrects the name in the locals.tf file of the aws-backup-source module.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ x ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ x ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ x ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ x ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
