### PR TITLE
Added new statement into the kms key to allow RDS Cross Account Copy Jobs

### DIFF
--- a/modules/aws-backup-source/kms.tf
+++ b/modules/aws-backup-source/kms.tf
@@ -10,6 +10,11 @@ resource "aws_kms_alias" "backup_key" {
   target_key_id = aws_kms_key.aws_backup_key.key_id
 }
 
+resource "aws_kms_key_policy" "backup_key_policy" {
+  key_id = aws_kms_key.aws_backup_key.id
+  policy = data.aws_iam_policy_document.backup_key_policy.json
+}
+
 data "aws_iam_policy_document" "backup_key_policy" {
   #checkov:skip=CKV_AWS_109:See (CERSS-25168) for more info
   #checkov:skip=CKV_AWS_111:See (CERSS-25169) for more info
@@ -30,5 +35,22 @@ data "aws_iam_policy_document" "backup_key_policy" {
     }
     actions   = ["kms:*"]
     resources = ["*"]
+  }
+  statement {
+    sid = "Allow attachment of persistent resources"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.backup_copy_vault_account_id}:root"]
+    }
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:DescribeKey"
+    ]
+    resources = [aws_kms_key.aws_backup_key.arn]
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added new statement into the kms key to allow RDS Cross Account Copy Jobs

<!-- Describe your changes in detail. -->

## Context

In order for RDS cross account copy jobs to work they require the "Allow attachment of persistent resources" Statement in the KMS Key, so we have included it and refined the actions and resources so they are less permissive.

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)    (I can't seam to find CONTRIBUTING.md under the docs folder)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes    (we have tested the changes in our separate code base and they work)
- [ ] I have updated the documentation accordingly  (It's a small change so I'm not sure if this is necessary)
- [ x ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.