### PR TITLE
Backup Key Policy: use the terraform ARN provided rather than the calling role id

### DIFF
--- a/modules/aws-backup-source/kms.tf
+++ b/modules/aws-backup-source/kms.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "backup_key_policy" {
     sid = "EnableIAMUserPermissions"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root", data.aws_caller_identity.current.arn]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root", var.terraform_role_arn]
     }
     actions   = ["kms:*"]
     resources = ["*"]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Switch the `backup_key_policy` to use the `terraform_role_arn` variable, rather tan the current authenticated role ARN.

## Context

The `backup_key_policy` currently refers to the current caller identity to infer which role should be granted access to the key. This ARN can end up referring to temporary roles (e.g. Codebuild ephemeral roles) and so would induce a change with each deployment.

The policy should probably (needs to be confirmed by someone who knows more about the specific requirements for this role than I do)  use the passed in `terraform_role_arn` variable.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
