### PR TITLE
SPINECORE-6443: add copy_target_arn_list which is a list of arns

### DIFF
--- a/modules/aws-backup-destination/README.md
+++ b/modules/aws-backup-destination/README.md
@@ -16,6 +16,7 @@ The AWS Backup Module helps automates the setup of AWS Backup resources in a des
 | <a name="input_vault_lock_max_retention_days"></a> [vault\_lock\_max\_retention\_days](#input\_vault\_lock\_max\_retention\_days) | The maximum retention period that the vault retains its recovery points | `number` | `365` | no |
 | <a name="input_vault_lock_min_retention_days"></a> [vault\_lock\_min\_retention\_days](#input\_vault\_lock\_min\_retention\_days) | The minimum retention period that the vault retains its recovery points | `number` | `365` | no |
 | <a name="input_vault_lock_type"></a> [vault\_lock\_type](#input\_vault\_lock\_type) | The type of lock that the vault should be, will default to governance | `string` | `"governance"` | no |
+| <a name="input_copy_target_arn_list"></a> [copy\_target\_arn\_list](#input\_copy\_target\_arn\_list) | A list of target ARNs to which restore points are allowed to be copied | `list(string)` | `null` | no |
 
 ## Example
 

--- a/modules/aws-backup-destination/backup_vault_policy.tf
+++ b/modules/aws-backup-destination/backup_vault_policy.tf
@@ -57,11 +57,9 @@ data "aws_iam_policy_document" "vault_policy" {
       ]
       resources = ["*"]
       condition {
-        test     = "StringNotEquals"
+        test     = "ArnNotEquals"
         variable = "backup:CopyTargets"
-        values = [
-          "arn:aws:backup:${var.region}:${var.source_account_id}:backup-vault:${var.region}-${var.source_account_id}-backup-vault"
-        ]
+        values   = local.copy_targets
       }
     }
   }

--- a/modules/aws-backup-destination/locals.tf
+++ b/modules/aws-backup-destination/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  copy_targets = coalescelist(
+    var.copy_target_arn_list,
+    ["arn:aws:backup:${var.region}:${var.source_account_id}:backup-vault:${var.region}-${var.source_account_id}-backup-vault"]
+  )
+}

--- a/modules/aws-backup-destination/variables.tf
+++ b/modules/aws-backup-destination/variables.tf
@@ -65,3 +65,9 @@ variable "changeable_for_days" {
   type        = number
   default     = 14
 }
+
+variable "copy_target_arn_list" {
+  description = "A list of target ARNs to which restore points are allowed to be copied"
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Change test condition to check against `ArnNotEquals` which is more precise than `StringNotEquals` (as discussed with @regularfry)
- Adds a new `copy_target_arn_list` variable which allows the list of restoration accounts to be passed in dynamically
- Adds a `copy_targets` local to retain the pre-existing default restoration account from the blueprint 

## Context

Required as we needed a way to pass through a different restoration account ARN as well as being able to specify multiple ARNS which are valid for restoration.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ x ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ x ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ x ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
