### PR TITLE
Configure delete control

### DIFF
--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,3 +1,12 @@
+locals {
+  principal_arn_list_value = length(local.deletion_allowed_principal_arns) > 0 ? join(",", local.deletion_allowed_principal_arns) : null
+
+}
+
+output "backup_framework_principal_arn_list_value" {
+  value = local.principal_arn_list_value
+}
+
 resource "aws_backup_framework" "main" {
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-framework", "-", "_")
@@ -26,7 +35,7 @@ resource "aws_backup_framework" "main" {
 
     input_parameter {
       name  = "principalArnList"
-      value = length(local.deletion_allowed_principal_arns) > 0 ? join(",", local.deletion_allowed_principal_arns) : null
+      value = local.principal_arn_list_value
     }
   }
 

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -24,7 +24,7 @@ resource "aws_backup_framework" "main" {
       }
     }
 
-    dynamic "deletion" {
+    dynamic "setting" {
       for_each = length(local.deletion_allowed_principal_arns) > 0 ? [1] : []
       input_parameter {
         name  = "principalArnList"

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -26,7 +26,7 @@ resource "aws_backup_framework" "main" {
 
     input_parameter {
       name  = "principalArnList"
-      value = join(",", var.deletion_allowed_principal_arns)
+      value = join(",", local.deletion_allowed_principal_arns)
     }
   }
 

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -24,12 +24,9 @@ resource "aws_backup_framework" "main" {
       }
     }
 
-    dynamic "setting" {
-      for_each = length(local.deletion_allowed_principal_arns) > 0 ? [1] : []
-      input_parameter {
-        name  = "principalArnList"
-        value = join(",", local.deletion_allowed_principal_arns)
-      }
+    input_parameter {
+      name  = "principalArnList"
+      value = length(local.deletion_allowed_principal_arns) > 0 ? join(",", local.deletion_allowed_principal_arns) : null
     }
   }
 

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -24,9 +24,12 @@ resource "aws_backup_framework" "main" {
       }
     }
 
-    input_parameter {
-      name  = "principalArnList"
-      value = join(",", local.deletion_allowed_principal_arns)
+    dynamic "deletion" {
+      for_each = length(local.deletion_allowed_principal_arns) > 0 ? [1] : []
+      input_parameter {
+        name  = "principalArnList"
+        value = join(",", local.deletion_allowed_principal_arns)
+      }
     }
   }
 

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,6 +1,5 @@
 locals {
-  principal_arn_list_value = length(local.deletion_allowed_principal_arns) > 0 ? join(",", local.deletion_allowed_principal_arns) : null
-
+  principal_arn_list_value = local.deletion_allowed_principal_arns == null || length(local.deletion_allowed_principal_arns) == 0 ? [] : join(",", local.deletion_allowed_principal_arns)
 }
 resource "null_resource" "principal_arn_list_output" {
   triggers = {

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,6 +1,3 @@
-locals {
-  principal_arn_list_value = local.deletion_allowed_principal_arns == null || length(local.deletion_allowed_principal_arns) == 0 ? "" : join(",", local.deletion_allowed_principal_arns)
-}
 resource "null_resource" "principal_arn_list_output" {
   triggers = {
     always_run = timestamp()
@@ -26,19 +23,21 @@ resource "aws_backup_framework" "main" {
     }
   }
 
-  # Evaluates if backup vaults do not allow manual deletion of recovery points with the exception of certain IAM roles.
-  control {
-    name = "BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED"
+  dynamic "control" {
+    for_each = length(var.deletion_allowed_principal_arns) > 0 ? [1] : []
+    content {
+      name = "BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED"
 
-    scope {
-      tags = {
-        "environment_name" = var.environment_name
+      scope {
+        tags = {
+          "environment_name" = var.environment_name
+        }
       }
-    }
 
-    input_parameter {
-      name  = "principalArnList"
-      value = local.principal_arn_list_value
+      input_parameter {
+        name  = "principalArnList"
+        value = join(",", var.deletion_allowed_principal_arns)
+      }
     }
   }
 

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,5 +1,5 @@
 locals {
-  principal_arn_list_value = local.deletion_allowed_principal_arns == null || length(local.deletion_allowed_principal_arns) == 0 ? [] : join(",", local.deletion_allowed_principal_arns)
+  principal_arn_list_value = local.deletion_allowed_principal_arns == null || length(local.deletion_allowed_principal_arns) == 0 ? "" : join(",", local.deletion_allowed_principal_arns)
 }
 resource "null_resource" "principal_arn_list_output" {
   triggers = {

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -2,9 +2,13 @@ locals {
   principal_arn_list_value = length(local.deletion_allowed_principal_arns) > 0 ? join(",", local.deletion_allowed_principal_arns) : null
 
 }
-
-output "backup_framework_principal_arn_list_value" {
-  value = local.principal_arn_list_value
+resource "null_resource" "principal_arn_list_output" {
+  triggers = {
+    always_run = timestamp()
+  }
+  provisioner "local-exec" {
+    command = "echo 'principalArnListValue = \"${local.principal_arn_list_value}\"'"
+  }
 }
 
 resource "aws_backup_framework" "main" {

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -26,7 +26,7 @@ resource "aws_backup_framework" "main" {
 
     input_parameter {
       name  = "principalArnList"
-      value = var.terraform_role_arn
+      value = join(",", var.deletion_allowed_principal_arns)
     }
   }
 

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,12 +1,3 @@
-resource "null_resource" "principal_arn_list_output" {
-  triggers = {
-    always_run = timestamp()
-  }
-  provisioner "local-exec" {
-    command = "echo 'principalArnListValue = \"${local.principal_arn_list_value}\"'"
-  }
-}
-
 resource "aws_backup_framework" "main" {
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-framework", "-", "_")

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -1,4 +1,3 @@
 locals {
-  resource_name_prefix            = "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup"
-  deletion_allowed_principal_arns = var.deletion_allowed_principal_arns != null ? var.deletion_allowed_principal_arns : [var.terraform_role_arn]
+  resource_name_prefix = "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup"
 }

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  resource_name_prefix = "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup"
+  resource_name_prefix            = "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup"
+  deletion_allowed_principal_arns = var.deletion_allowed_principal_arns != null ? var.deletion_allowed_principal_arns : [var.terraform_role_arn]
 }

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -32,8 +32,7 @@ variable "terraform_role_arn" {
 variable "deletion_allowed_principal_arns" {
   description = "List of ARNs of principals allowed to delete backups."
   type        = list(string)
-  default     = null
-  nullable    = true
+  default     = []
 }
 
 variable "restore_testing_plan_algorithm" {

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -32,7 +32,8 @@ variable "terraform_role_arn" {
 variable "deletion_allowed_principal_arns" {
   description = "List of ARNs of principals allowed to delete backups."
   type        = list(string)
-  default     = []
+  default     = null
+  nullable    = true
 }
 
 variable "restore_testing_plan_algorithm" {

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -32,7 +32,8 @@ variable "terraform_role_arn" {
 variable "deletion_allowed_principal_arns" {
   description = "List of ARNs of principals allowed to delete backups."
   type        = list(string)
-  default     = [var.terraform_role_arn]
+  default     = null
+  nullable    = true
 }
 
 variable "restore_testing_plan_algorithm" {

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -29,6 +29,12 @@ variable "terraform_role_arn" {
   type        = string
 }
 
+variable "deletion_allowed_principal_arns" {
+  description = "List of ARNs of principals allowed to delete backups."
+  type        = list(string)
+  default     = [var.terraform_role_arn]
+}
+
 variable "restore_testing_plan_algorithm" {
   description = "Algorithm of the Recovery Selection Point"
   type        = string


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Allow the `BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED` control to be switched on and off, and configured with custom allow lists.

## Context

The `BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED` control as previously configured was preventing this module from being consumed as a git URL.  The reason was a little obscure and hard to spot.

Previously, we had this:

```
input_parameter {
      name  = "principalArnList"
      value = var.terraform_role_arn
}

The `principalArnList` input here is used to tell the framework control which principals *are* allowed to delete recovery points.  It's documented [here](https://docs.aws.amazon.com/config/latest/developerguide/backup-recovery-point-manual-deletion-disabled.html).

When deployed in a GitHub Actions pipeline, configured as recommended with an OIDC provider, the `var.terraform_role_arn` value was fed through as an assumed role.  Unfortunately, assumed roles aren't valid here, and the creation failed.

The result was recommending that teams remove the control entirely, to be able to use the module.  Implicitly the control was disabled for any team which did so: reports would not cover who was allowed to disable recovery points.

This change re-introduces the control together with an input variable (`deletion_allowed_principal_arns`) which allows the calling module to specify that the control either:

- is disabled, by leaving it out or setting it explicitly to `null`;
- prevents anyone from deleting recovery points, by passing in the empty list `[]`; or
- explicitly allows a defined list of principals to do so.

This should be backwards compatible for anyone consuming this module, and at this point the module should be consumable via git url like so:

```
module "source" {
  source = "github.com/NHSDigital/terraform-aws-backup//modules/aws-backup-source?ref=alyo2-v1.1.0-configure-delete-control"
  ...
```

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
