### PR TITLE
Allow hashicorp/aws > 5

### DIFF
--- a/modules/aws-backup-source/versions.tf
+++ b/modules/aws-backup-source/versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "> 5"
     }
 
     awscc = {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This allows v6 and later of `hashicorp/aws`.

## Context

v6 has been published since the version of the blueprint which introduced the version specs, and we have no reason not to allow it.