### PR TITLE
Don't error on the default value

### DIFF
--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -30,7 +30,7 @@ variable "terraform_role_arn" {
   default     = ""
 
   validation {
-    condition     =  var.terraform_role_arn == null
+    condition     =  var.terraform_role_arn == ""
     error_message = "Warning: 'terraform_role_arn' is deprecated and should not be used."
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change the expected value of `terraform_role_arn` from `null` to `""`.

## Context

With the default value set to `""`, the validation condition would raise an error if you left the value unset.  That's exactly what we don't want.
