### PR TITLE
Alow null name prefix

### DIFF
--- a/modules/aws-backup-destination/variables.tf
+++ b/modules/aws-backup-destination/variables.tf
@@ -84,7 +84,7 @@ variable "name_prefix" {
   type        = string
   default     = null
   validation {
-    condition     = can(regex("^[^0-9]*$", var.name_prefix))
+    condition     = var.name_prefix == null || can(regex("^[^0-9]*$", var.name_prefix))
     error_message = "The name_prefix must not contain any numbers."
   }
 }

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,5 +1,5 @@
 resource "aws_backup_framework" "main" {
-  name        = "${local.resource_name_prefix}-framework"
+  name        = "${local.resource_name_prefix}_framework"
   description = "${var.project_name} Backup Framework"
 
   # Evaluates if recovery points are encrypted.
@@ -173,7 +173,7 @@ resource "aws_backup_framework" "dynamodb" {
 
 resource "aws_backup_framework" "ebsvol" {
   count       = var.backup_plan_config_ebsvol.enable ? 1 : 0
-  name        = "${local.resource_name_prefix}-ebsvol-framework"
+  name        = "${local.resource_name_prefix}_ebsvol_framework"
   description = "${var.project_name} EBS Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.
@@ -213,7 +213,7 @@ resource "aws_backup_framework" "ebsvol" {
 
 resource "aws_backup_framework" "aurora" {
   count       = var.backup_plan_config_aurora.enable ? 1 : 0
-  name        = "${local.resource_name_prefix}-aurora-framework"
+  name        = "${local.resource_name_prefix}_aurora_framework"
   description = "${var.project_name} Aurora Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,6 +1,5 @@
 resource "aws_backup_framework" "main" {
-  # must be underscores instead of dashes
-  name        = replace("${local.resource_name_prefix}-framework", "-", "_")
+  name        = "${local.resource_name_prefix}-framework"
   description = "${var.project_name} Backup Framework"
 
   # Evaluates if recovery points are encrypted.
@@ -173,9 +172,8 @@ resource "aws_backup_framework" "dynamodb" {
 }
 
 resource "aws_backup_framework" "ebsvol" {
-  count = var.backup_plan_config_ebsvol.enable ? 1 : 0
-  # must be underscores instead of dashes
-  name        = replace("${local.resource_name_prefix}-ebsvol-framework", "-", "_")
+  count       = var.backup_plan_config_ebsvol.enable ? 1 : 0
+  name        = "${local.resource_name_prefix}-ebsvol-framework"
   description = "${var.project_name} EBS Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.
@@ -214,9 +212,8 @@ resource "aws_backup_framework" "ebsvol" {
 }
 
 resource "aws_backup_framework" "aurora" {
-  count = var.backup_plan_config_aurora.enable ? 1 : 0
-  # must be underscores instead of dashes
-  name        = replace("${local.resource_name_prefix}-aurora-framework", "-", "_")
+  count       = var.backup_plan_config_aurora.enable ? 1 : 0
+  name        = "${local.resource_name_prefix}-aurora-framework"
   description = "${var.project_name} Aurora Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,6 +1,6 @@
 resource "aws_backup_framework" "main" {
   # must be underscores instead of dashes
-  name        = replace("${var.name_prefix}-framework", "-", "_")
+  name        = replace("${local.resource_name_prefix}-framework", "-", "_")
   description = "${var.project_name} Backup Framework"
 
   # Evaluates if recovery points are encrypted.
@@ -175,7 +175,7 @@ resource "aws_backup_framework" "dynamodb" {
 resource "aws_backup_framework" "ebsvol" {
   count = var.backup_plan_config_ebsvol.enable ? 1 : 0
   # must be underscores instead of dashes
-  name        = replace("${var.name_prefix}-ebsvol-framework", "-", "_")
+  name        = replace("${local.resource_name_prefix}-ebsvol-framework", "-", "_")
   description = "${var.project_name} EBS Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.

--- a/modules/aws-backup-source/backup_report_plan.tf
+++ b/modules/aws-backup-source/backup_report_plan.tf
@@ -35,7 +35,7 @@ resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
 }
 
 resource "aws_backup_report_plan" "resource_compliance" {
-  name        = replace("${local.resource_name_prefix}_resource_compliance", "-", "_")
+  name        = "${local.resource_name_prefix}_resource_compliance"
   description = "Report for showing whether resources are compliant with the framework"
 
   report_delivery_channel {
@@ -55,7 +55,7 @@ resource "aws_backup_report_plan" "resource_compliance" {
 
 resource "aws_backup_report_plan" "copy_jobs" {
   count       = var.backup_copy_vault_arn != "" && var.backup_copy_vault_account_id != "" ? 1 : 0
-  name        = replace("${local.resource_name_prefix}_copy_jobs", "-", "_")
+  name        = "${local.resource_name_prefix}_copy_jobs"
   description = "Report for showing whether copies ran successfully in the last 24 hours"
 
   report_delivery_channel {

--- a/modules/aws-backup-source/backup_report_plan.tf
+++ b/modules/aws-backup-source/backup_report_plan.tf
@@ -35,7 +35,7 @@ resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
 }
 
 resource "aws_backup_report_plan" "resource_compliance" {
-  name        = "${local.resource_name_prefix}_resource_compliance"
+  name        = replace("${local.resource_name_prefix}_resource_compliance", "-", "_")
   description = "Report for showing whether resources are compliant with the framework"
 
   report_delivery_channel {
@@ -55,7 +55,7 @@ resource "aws_backup_report_plan" "resource_compliance" {
 
 resource "aws_backup_report_plan" "copy_jobs" {
   count       = var.backup_copy_vault_arn != "" && var.backup_copy_vault_account_id != "" ? 1 : 0
-  name        = "${local.resource_name_prefix}_copy_jobs"
+  name        = replace("${local.resource_name_prefix}_copy_jobs", "-", "_")
   description = "Report for showing whether copies ran successfully in the last 24 hours"
 
   report_delivery_channel {

--- a/modules/aws-backup-source/backup_report_plan.tf
+++ b/modules/aws-backup-source/backup_report_plan.tf
@@ -1,6 +1,6 @@
 # Create the reports
 resource "aws_backup_report_plan" "backup_jobs" {
-  name        = "${var.name_prefix}_backup_jobs"
+  name        = "${local.resource_name_prefix}_backup_jobs"
   description = "Report for showing whether backups ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -18,7 +18,7 @@ resource "aws_backup_report_plan" "backup_jobs" {
 
 # Create the restore testing completion reports
 resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
-  name        = "${var.name_prefix}_backup_restore_testing_jobs"
+  name        = "${local.resource_name_prefix}_backup_restore_testing_jobs"
   description = "Report for showing whether backup restore test ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -35,7 +35,7 @@ resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
 }
 
 resource "aws_backup_report_plan" "resource_compliance" {
-  name        = "${var.name_prefix}_resource_compliance"
+  name        = "${local.resource_name_prefix}_resource_compliance"
   description = "Report for showing whether resources are compliant with the framework"
 
   report_delivery_channel {
@@ -55,7 +55,7 @@ resource "aws_backup_report_plan" "resource_compliance" {
 
 resource "aws_backup_report_plan" "copy_jobs" {
   count       = var.backup_copy_vault_arn != "" && var.backup_copy_vault_account_id != "" ? 1 : 0
-  name        = "${var.name_prefix}_copy_jobs"
+  name        = "${local.resource_name_prefix}_copy_jobs"
   description = "Report for showing whether copies ran successfully in the last 24 hours"
 
   report_delivery_channel {

--- a/modules/aws-backup-source/backup_vault.tf
+++ b/modules/aws-backup-source/backup_vault.tf
@@ -1,4 +1,4 @@
 resource "aws_backup_vault" "main" {
-  name        = "${var.name_prefix}-vault"
+  name        = replace("${local.resource_name_prefix}-vault", "_", "-")
   kms_key_arn = aws_kms_key.aws_backup_key.arn
 }

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -12,6 +12,6 @@ locals {
     var.backup_plan_config_dynamodb.enable ? [aws_backup_framework.dynamodb[0].arn] : [],
     var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : []
   ))
-  aurora_overrides = jsondecode(var.backup_plan_config_aurora.restore_testing_overrides || "null")
+  aurora_overrides = var.backup_plan_config_aurora.restore_testing_overrides == null ? null : jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
   terraform_role_arns = var.terraform_role_arns != null ? var.terraform_role_arns : [var.terraform_role_arn]
 }

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_name_prefix                      = var.name_prefix != null ? var.name_prefix : "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup"
+  resource_name_prefix                      = replace(var.name_prefix != null ? var.name_prefix : "${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}-backup", "-", "_")
   selection_tag_value_null_checked          = (var.backup_plan_config.selection_tag_value == null) ? "True" : var.backup_plan_config.selection_tag_value
   selection_tag_value_dynamodb_null_checked = (var.backup_plan_config_dynamodb.selection_tag_value == null) ? "True" : var.backup_plan_config_dynamodb.selection_tag_value
   selection_tags_null_checked               = (var.backup_plan_config.selection_tags == null) ? [{ "key" : var.backup_plan_config.selection_tag, "value" : local.selection_tag_value_null_checked }] : var.backup_plan_config.selection_tags
@@ -12,6 +12,6 @@ locals {
     var.backup_plan_config_dynamodb.enable ? [aws_backup_framework.dynamodb[0].arn] : [],
     var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : []
   ))
-  aurora_overrides = var.backup_plan_config_aurora.restore_testing_overrides == null ? null : jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
+  aurora_overrides    = var.backup_plan_config_aurora.restore_testing_overrides == null ? null : jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
   terraform_role_arns = var.terraform_role_arns != null ? var.terraform_role_arns : [var.terraform_role_arn]
 }

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -12,6 +12,6 @@ locals {
     var.backup_plan_config_dynamodb.enable ? [aws_backup_framework.dynamodb[0].arn] : [],
     var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : []
   ))
-  aurora_overrides = jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
+  aurora_overrides = jsondecode(var.backup_plan_config_aurora.restore_testing_overrides || "null")
   terraform_role_arns = var.terraform_role_arns != null ? var.terraform_role_arns : [var.terraform_role_arn]
 }

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -28,11 +28,11 @@ variable "terraform_role_arn" {
   description = "ARN of Terraform role used to deploy to account (deprecated, please swap to terraform_role_arns)"
   type        = string
   default     = ""
+}
 
-  validation {
-    condition     =  var.terraform_role_arn == ""
-    error_message = "Warning: 'terraform_role_arn' is deprecated and should not be used."
-  }
+resource "validation_warning" "terraform_role_arn_deprecated" {
+  summary   = "The 'terraform_role_arn' variable is deprecated. Please use 'terraform_role_arns' instead."
+  condition = var.terraform_role_arn != ""
 }
 
 variable "terraform_role_arns" {

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -236,8 +236,9 @@ variable "backup_plan_config_dynamodb" {
 variable "name_prefix" {
   description = "Name prefix for vault resources"
   type        = string
+  default     = null
   validation {
-    condition     = can(regex("^[^0-9]*$", var.name_prefix))
+    condition     = var.name_prefix == null || can(regex("^[^0-9]*$", var.name_prefix))
     error_message = "The name_prefix must not contain any numbers."
   }
 }

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -30,11 +30,6 @@ variable "terraform_role_arn" {
   default     = ""
 }
 
-resource "validation_warning" "terraform_role_arn_deprecated" {
-  summary   = "The 'terraform_role_arn' variable is deprecated. Please use 'terraform_role_arns' instead."
-  condition = var.terraform_role_arn != ""
-}
-
 variable "terraform_role_arns" {
   description = "ARN of Terraform roles used to deploy to account, defaults to caller arn if list is empty"
   type        = list(string)

--- a/modules/aws-backup-source/versions.tf
+++ b/modules/aws-backup-source/versions.tf
@@ -14,9 +14,12 @@ terraform {
       source  = "hashicorp/awscc"
       version = "~> 1"
     }
+
+    validation = {
+      source  = "hashicorp/validation"
+      version = "~>1"
+    }
   }
 
   required_version = ">= 1.9.5"
 }
-
-provider "validation" {}

--- a/modules/aws-backup-source/versions.tf
+++ b/modules/aws-backup-source/versions.tf
@@ -14,11 +14,6 @@ terraform {
       source  = "hashicorp/awscc"
       version = "~> 1"
     }
-
-    validation = {
-      source  = "hashicorp/validation"
-      version = "~>1"
-    }
   }
 
   required_version = ">= 1.9.5"

--- a/modules/aws-backup-source/versions.tf
+++ b/modules/aws-backup-source/versions.tf
@@ -18,3 +18,5 @@ terraform {
 
   required_version = ">= 1.9.5"
 }
+
+provider "validation" {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
The setup of `var.name_prefix` on `main` assumes that everyone using the blueprint must already be defining a value. This isn't true: anyone who didn't upgrade from v1.1.0 (or earlier) wouldn't have necessarily had it.  The current code doesn't handle it not being supplied.

This change adds sensible defaults which match the previous versions without the `name_prefix`, allowing a direct upgrade without a resource rename for those projects which never defined it.
