### PR TITLE
Allow null name prefix

### DIFF
--- a/modules/aws-backup-destination/variables.tf
+++ b/modules/aws-backup-destination/variables.tf
@@ -52,7 +52,7 @@ variable "vault_lock_type" {
   # See toplevel README.md:
   #   DO NOT SET THIS TO compliance UNTIL YOU ARE SURE THAT YOU WANT TO LOCK THE VAULT PERMANENTLY
   # When you do, you will also need to set "enable_vault_protection" to true for it to take effect.
-  default     = "governance"
+  default = "governance"
 }
 
 variable "vault_lock_min_retention_days" {
@@ -84,7 +84,7 @@ variable "name_prefix" {
   type        = string
   default     = null
   validation {
-    condition     = can(regex("^[^0-9]*$", var.name_prefix))
+    condition     = var.name_prefix == null || can(regex("^[^0-9]*$", var.name_prefix))
     error_message = "The name_prefix must not contain any numbers."
   }
 }

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,6 +1,6 @@
 resource "aws_backup_framework" "main" {
   # must be underscores instead of dashes
-  name        = replace("${var.name_prefix}-framework", "-", "_")
+  name        = replace("${local.resource_name_prefix}-framework", "-", "_")
   description = "${var.project_name} Backup Framework"
 
   # Evaluates if recovery points are encrypted.
@@ -134,7 +134,7 @@ resource "aws_backup_framework" "main" {
 resource "aws_backup_framework" "dynamodb" {
   count = var.backup_plan_config_dynamodb.enable ? 1 : 0
   # must be underscores instead of dashes
-  name        = replace("${var.name_prefix}-dynamodb-framework", "-", "_")
+  name        = replace("${local.resource_name_prefix}-dynamodb-framework", "-", "_")
   description = "${var.project_name} DynamoDB Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.
@@ -175,7 +175,7 @@ resource "aws_backup_framework" "dynamodb" {
 resource "aws_backup_framework" "ebsvol" {
   count = var.backup_plan_config_ebsvol.enable ? 1 : 0
   # must be underscores instead of dashes
-  name        = replace("${var.name_prefix}-ebsvol-framework", "-", "_")
+  name        = replace("${local.resource_name_prefix}-ebsvol-framework", "-", "_")
   description = "${var.project_name} EBS Backup Framework"
 
   # Evaluates if resources are protected by a backup plan.

--- a/modules/aws-backup-source/backup_plan.tf
+++ b/modules/aws-backup-source/backup_plan.tf
@@ -1,5 +1,5 @@
 resource "aws_backup_plan" "default" {
-  name = "${var.name_prefix}-plan"
+  name = "${local.resource_name_prefix}-plan"
 
   dynamic "rule" {
     for_each = var.backup_plan_config.rules
@@ -32,7 +32,7 @@ resource "aws_backup_plan" "default" {
 # this backup plan shouldn't include a continous backup rule as it isn't supported for DynamoDB
 resource "aws_backup_plan" "dynamodb" {
   count = var.backup_plan_config_dynamodb.enable ? 1 : 0
-  name  = "${var.name_prefix}-dynamodb-plan"
+  name  = "${local.resource_name_prefix}-dynamodb-plan"
 
   dynamic "rule" {
     for_each = var.backup_plan_config_dynamodb.rules
@@ -63,7 +63,7 @@ resource "aws_backup_plan" "dynamodb" {
 
 resource "aws_backup_plan" "ebsvol" {
   count = var.backup_plan_config_ebsvol.enable ? 1 : 0
-  name  = "${var.name_prefix}-ebsvol-plan"
+  name  = "${local.resource_name_prefix}-ebsvol-plan"
 
   dynamic "rule" {
     for_each = var.backup_plan_config_ebsvol.rules
@@ -124,7 +124,7 @@ resource "aws_backup_plan" "aurora" {
 
 resource "aws_backup_selection" "default" {
   iam_role_arn = aws_iam_role.backup.arn
-  name         = "${var.name_prefix}-selection"
+  name         = "${local.resource_name_prefix}-selection"
   plan_id      = aws_backup_plan.default.id
 
   selection_tag {
@@ -146,7 +146,7 @@ resource "aws_backup_selection" "default" {
 resource "aws_backup_selection" "dynamodb" {
   count        = var.backup_plan_config_dynamodb.enable ? 1 : 0
   iam_role_arn = aws_iam_role.backup.arn
-  name         = "${var.name_prefix}-dynamodb-selection"
+  name         = "${local.resource_name_prefix}-dynamodb-selection"
   plan_id      = aws_backup_plan.dynamodb[0].id
 
   selection_tag {
@@ -168,7 +168,7 @@ resource "aws_backup_selection" "dynamodb" {
 resource "aws_backup_selection" "ebsvol" {
   count        = var.backup_plan_config_ebsvol.enable ? 1 : 0
   iam_role_arn = aws_iam_role.backup.arn
-  name         = "${var.name_prefix}-ebsvol-selection"
+  name         = "${local.resource_name_prefix}-ebsvol-selection"
   plan_id      = aws_backup_plan.ebsvol[0].id
 
   selection_tag {

--- a/modules/aws-backup-source/backup_report_plan.tf
+++ b/modules/aws-backup-source/backup_report_plan.tf
@@ -1,6 +1,6 @@
 # Create the reports
 resource "aws_backup_report_plan" "backup_jobs" {
-  name        = "${var.name_prefix}_backup_jobs"
+  name        = var.name_prefix != null ? "${var.name_prefix}_backup_jobs" : "backup_jobs"
   description = "Report for showing whether backups ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -18,7 +18,7 @@ resource "aws_backup_report_plan" "backup_jobs" {
 
 # Create the restore testing completion reports
 resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
-  name        = "${var.name_prefix}_backup_restore_testing_jobs"
+  name        = var.name_prefix != null ? "${var.name_prefix}_backup_restore_testing_jobs" : "backup_restore_testing_jobs"
   description = "Report for showing whether backup restore test ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -35,7 +35,7 @@ resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
 }
 
 resource "aws_backup_report_plan" "resource_compliance" {
-  name        = "${var.name_prefix}_resource_compliance"
+  name        = var.name_prefix != null ? "${var.name_prefix}_resource_compliance" : "resource_compliance"
   description = "Report for showing whether resources are compliant with the framework"
 
   report_delivery_channel {
@@ -55,7 +55,7 @@ resource "aws_backup_report_plan" "resource_compliance" {
 
 resource "aws_backup_report_plan" "copy_jobs" {
   count       = var.backup_copy_vault_arn != "" && var.backup_copy_vault_account_id != "" ? 1 : 0
-  name        = "${var.name_prefix}_copy_jobs"
+  name        = var.name_prefix != null ? "${var.name_prefix}_copy_jobs" : "copy_jobs"
   description = "Report for showing whether copies ran successfully in the last 24 hours"
 
   report_delivery_channel {

--- a/modules/aws-backup-source/backup_restore_testing.tf
+++ b/modules/aws-backup-source/backup_restore_testing.tf
@@ -1,5 +1,5 @@
 resource "awscc_backup_restore_testing_plan" "backup_restore_testing_plan" {
-  restore_testing_plan_name = "${var.name_prefix}_backup_restore_testing_plan"
+  restore_testing_plan_name = var.name_prefix != null ? "${var.name_prefix}_backup_restore_testing_plan" : "backup_restore_testing_plan"
   schedule_expression       = var.restore_testing_plan_scheduled_expression
   start_window_hours        = var.restore_testing_plan_start_window
   recovery_point_selection = {

--- a/modules/aws-backup-source/backup_vault.tf
+++ b/modules/aws-backup-source/backup_vault.tf
@@ -1,4 +1,4 @@
 resource "aws_backup_vault" "main" {
-  name        = "${var.name_prefix}-vault"
+  name        = "${local.resource_name_prefix}-vault"
   kms_key_arn = aws_kms_key.aws_backup_key.arn
 }

--- a/modules/aws-backup-source/kms.tf
+++ b/modules/aws-backup-source/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "aws_backup_key" {
 }
 
 resource "aws_kms_alias" "backup_key" {
-  name          = "alias/${var.name_prefix}/backup-key"
+  name          = var.name_prefix != null ? "alias/${var.name_prefix}/backup-key" : "alias/${var.environment_name}/backup-key"
   target_key_id = aws_kms_key.aws_backup_key.key_id
 }
 

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -12,6 +12,6 @@ locals {
     var.backup_plan_config_dynamodb.enable ? [aws_backup_framework.dynamodb[0].arn] : [],
     var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : []
   ))
-  aurora_overrides = jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
+  aurora_overrides    = var.backup_plan_config_aurora.restore_testing_overrides == null ? null : jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
   terraform_role_arns = var.terraform_role_arns != null ? var.terraform_role_arns : [var.terraform_role_arn]
 }

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -28,11 +28,6 @@ variable "terraform_role_arn" {
   description = "ARN of Terraform role used to deploy to account (deprecated, please swap to terraform_role_arns)"
   type        = string
   default     = ""
-
-  validation {
-    condition     =  var.terraform_role_arn == ""
-    error_message = "Warning: 'terraform_role_arn' is deprecated and should not be used."
-  }
 }
 
 variable "terraform_role_arns" {
@@ -236,8 +231,9 @@ variable "backup_plan_config_dynamodb" {
 variable "name_prefix" {
   description = "Name prefix for vault resources"
   type        = string
+  default     = null
   validation {
-    condition     = can(regex("^[^0-9]*$", var.name_prefix))
+    condition     = var.name_prefix == null || can(regex("^[^0-9]*$", var.name_prefix))
     error_message = "The name_prefix must not contain any numbers."
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description


The setup of var.name_prefix on main assumes that everyone using the blueprint must already be defining a value. This isn't true: anyone who didn't upgrade from v1.1.0 (or earlier) wouldn't have necessarily had it. The current code doesn't handle it not being supplied.

This change adds sensible defaults which match the previous versions without the name_prefix, allowing a direct upgrade without a resource rename for those projects which never defined it.

There is one item to be cautious of here, and that's the backup key alias.  We now define its `name` as:

```
var.name_prefix != null ? "alias/${var.name_prefix}/backup-key" : "alias/${var.environment_name}/backup-key"
```

The `var.environment_name` version is what was in `v1.1.0`, but there's been an intermediate version with `local.resource_name_prefix` since then.