### PR TITLE
Default selection tag values

### DIFF
--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -103,7 +103,7 @@ resource "aws_backup_framework" "main" {
     scope {
       compliance_resource_types = var.backup_plan_config.compliance_resource_types
       tags = {
-        (var.backup_plan_config.selection_tag) = (var.backup_plan_config.selection_tag_value || "True")
+        (var.backup_plan_config.selection_tag) = var.backup_plan_config.selection_tag_value ? var.backup_plan_config.selection_tag_value : "True"
       }
     }
   }
@@ -125,7 +125,7 @@ resource "aws_backup_framework" "main" {
     scope {
       compliance_resource_types = var.backup_plan_config.compliance_resource_types
       tags = {
-        (var.backup_plan_config.selection_tag) = (var.backup_plan_config.selection_tag_value || "True")
+        (var.backup_plan_config.selection_tag) = var.backup_plan_config.selection_tag_value ? var.backup_plan_config.selection_tag_value : "True"
       }
     }
   }
@@ -144,7 +144,7 @@ resource "aws_backup_framework" "dynamodb" {
     scope {
       compliance_resource_types = var.backup_plan_config_dynamodb.compliance_resource_types
       tags = {
-        (var.backup_plan_config_dynamodb.selection_tag) = (var.backup_plan_config_dynamodb.selection_tag_value || "True")
+        (var.backup_plan_config_dynamodb.selection_tag) = var.backup_plan_config_dynamodb.selection_tag_value ? var.backup_plan_config_dynamodb.selection_tag_value : "True"
       }
     }
   }
@@ -166,7 +166,7 @@ resource "aws_backup_framework" "dynamodb" {
     scope {
       compliance_resource_types = var.backup_plan_config_dynamodb.compliance_resource_types
       tags = {
-        (var.backup_plan_config_dynamodb.selection_tag) = (var.backup_plan_config_dynamodb.selection_tag_value || "True")
+        (var.backup_plan_config_dynamodb.selection_tag) = var.backup_plan_config_dynamodb.selection_tag_value ? var.backup_plan_config_dynamodb.selection_tag_value : "True"
       }
     }
   }

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -103,7 +103,7 @@ resource "aws_backup_framework" "main" {
     scope {
       compliance_resource_types = var.backup_plan_config.compliance_resource_types
       tags = {
-        (var.backup_plan_config.selection_tag) = var.backup_plan_config.selection_tag_value ? var.backup_plan_config.selection_tag_value : "True"
+        (var.backup_plan_config.selection_tag) = var.backup_plan_config.selection_tag_value != null ? var.backup_plan_config.selection_tag_value : "True"
       }
     }
   }
@@ -125,7 +125,7 @@ resource "aws_backup_framework" "main" {
     scope {
       compliance_resource_types = var.backup_plan_config.compliance_resource_types
       tags = {
-        (var.backup_plan_config.selection_tag) = var.backup_plan_config.selection_tag_value ? var.backup_plan_config.selection_tag_value : "True"
+        (var.backup_plan_config.selection_tag) = var.backup_plan_config.selection_tag_value != null ? var.backup_plan_config.selection_tag_value : "True"
       }
     }
   }
@@ -144,7 +144,7 @@ resource "aws_backup_framework" "dynamodb" {
     scope {
       compliance_resource_types = var.backup_plan_config_dynamodb.compliance_resource_types
       tags = {
-        (var.backup_plan_config_dynamodb.selection_tag) = var.backup_plan_config_dynamodb.selection_tag_value ? var.backup_plan_config_dynamodb.selection_tag_value : "True"
+        (var.backup_plan_config_dynamodb.selection_tag) = var.backup_plan_config_dynamodb.selection_tag_value != null ? var.backup_plan_config_dynamodb.selection_tag_value : "True"
       }
     }
   }
@@ -166,7 +166,7 @@ resource "aws_backup_framework" "dynamodb" {
     scope {
       compliance_resource_types = var.backup_plan_config_dynamodb.compliance_resource_types
       tags = {
-        (var.backup_plan_config_dynamodb.selection_tag) = var.backup_plan_config_dynamodb.selection_tag_value ? var.backup_plan_config_dynamodb.selection_tag_value : "True"
+        (var.backup_plan_config_dynamodb.selection_tag) = var.backup_plan_config_dynamodb.selection_tag_value != null ? var.backup_plan_config_dynamodb.selection_tag_value : "True"
       }
     }
   }

--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -103,7 +103,7 @@ resource "aws_backup_framework" "main" {
     scope {
       compliance_resource_types = var.backup_plan_config.compliance_resource_types
       tags = {
-        (var.backup_plan_config.selection_tag) = (var.backup_plan_config.selection_tag_value)
+        (var.backup_plan_config.selection_tag) = (var.backup_plan_config.selection_tag_value || "True")
       }
     }
   }
@@ -125,7 +125,7 @@ resource "aws_backup_framework" "main" {
     scope {
       compliance_resource_types = var.backup_plan_config.compliance_resource_types
       tags = {
-        (var.backup_plan_config.selection_tag) = (var.backup_plan_config.selection_tag_value)
+        (var.backup_plan_config.selection_tag) = (var.backup_plan_config.selection_tag_value || "True")
       }
     }
   }
@@ -144,7 +144,7 @@ resource "aws_backup_framework" "dynamodb" {
     scope {
       compliance_resource_types = var.backup_plan_config_dynamodb.compliance_resource_types
       tags = {
-        (var.backup_plan_config_dynamodb.selection_tag) = (var.backup_plan_config_dynamodb.selection_tag_value)
+        (var.backup_plan_config_dynamodb.selection_tag) = (var.backup_plan_config_dynamodb.selection_tag_value || "True")
       }
     }
   }
@@ -166,7 +166,7 @@ resource "aws_backup_framework" "dynamodb" {
     scope {
       compliance_resource_types = var.backup_plan_config_dynamodb.compliance_resource_types
       tags = {
-        (var.backup_plan_config_dynamodb.selection_tag) = (var.backup_plan_config_dynamodb.selection_tag_value)
+        (var.backup_plan_config_dynamodb.selection_tag) = (var.backup_plan_config_dynamodb.selection_tag_value || "True")
       }
     }
   }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Making `selection_tag_value` optional had the unfortunate effect that if you didn't specify it, the tags would be removed as selectors from the backup framework control scopes when you upgraded to 1.3.0-rc2.  That meant the associated controls would be deleted and recreated, with unexpected effects.

This patch re-introduces a default value of `"True"` for the `selection_tag_value`.  This value *is* present in the default backup config, but if you pass any backup config that doesn't include a `selection_tag_value` then the default is lost and is interpreted as `null`.  So we need to specify it again here.