### PR TITLE
Tweak terraform_role_arns default

### DIFF
--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -13,5 +13,5 @@ locals {
     var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : []
   ))
   aurora_overrides    = var.backup_plan_config_aurora.restore_testing_overrides == null ? null : jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
-  terraform_role_arns = var.terraform_role_arns != null ? var.terraform_role_arns : [var.terraform_role_arn]
+  terraform_role_arns = var.terraform_role_arns != [] ? var.terraform_role_arns : [var.terraform_role_arn]
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

With a default value of `[]`, `var.terraform_role_arns` would never be `null`.  So the check in `locals.tf` which constructs the list if one isn't supplied never matched; the result was that privileges were removed when they shouldn't be.

This change fixes the check to look for `[]` rather than `null`.  This does mean that if you explicitly set `var.terraform_role_arns` to the empty list then that choice is indistinguishable from not having set one, so you *do* get the terraform role arn set in that case.
