### PR TITLE
Switch from array comparison to length check

### DIFF
--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -13,5 +13,5 @@ locals {
     var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : []
   ))
   aurora_overrides    = var.backup_plan_config_aurora.restore_testing_overrides == null ? null : jsondecode(var.backup_plan_config_aurora.restore_testing_overrides)
-  terraform_role_arns = var.terraform_role_arns != [] ? var.terraform_role_arns : [var.terraform_role_arn]
+  terraform_role_arns = length(var.terraform_role_arns) > 0 ? var.terraform_role_arns : [var.terraform_role_arn]
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
The comparison to an empty list in `var.terraform_role_arns` doesn't work because the values [end up the wrong types](https://developer.hashicorp.com/terraform/language/expressions/operators#equality-operators).  This switches the comparison so you end up with the expected default in the case where no value is specified.