### PR TITLE
ENG-849 Add destination vault name as output

### DIFF
--- a/modules/aws-backup-destination/backup.tf
+++ b/modules/aws-backup-destination/backup.tf
@@ -6,3 +6,8 @@ resource "aws_backup_vault" "vault" {
 output "vault_arn" {
   value = aws_backup_vault.vault.arn
 }
+
+output "vault_name" {
+  description = "The name of the backup vault."
+  value       = aws_backup_vault.vault.name
+}


### PR DESCRIPTION
This patch adds the destination vault name as an output from the `aws-backup-destination` module.  This is needed because you can't pass an ARN to the [`aws_backup_vault` terraform data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/backup_vault), so if you want to refer to the vault from a different config you're a bit stuck.
