### PR TITLE
ENG-1290: Allow to include environment name in resource names.

### DIFF
--- a/modules/aws-backup-source/backup_report_plan.tf
+++ b/modules/aws-backup-source/backup_report_plan.tf
@@ -1,6 +1,6 @@
 # Create the reports
 resource "aws_backup_report_plan" "backup_jobs" {
-  name        = var.name_prefix != null ? "${var.name_prefix}_backup_jobs" : "backup_jobs"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_jobs" : "backup_jobs"
   description = "Report for showing whether backups ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -18,7 +18,7 @@ resource "aws_backup_report_plan" "backup_jobs" {
 
 # Create the restore testing completion reports
 resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
-  name        = var.name_prefix != null ? "${var.name_prefix}_backup_restore_testing_jobs" : "backup_restore_testing_jobs"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_restore_testing_jobs" : "backup_restore_testing_jobs"
   description = "Report for showing whether backup restore test ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -35,7 +35,7 @@ resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
 }
 
 resource "aws_backup_report_plan" "resource_compliance" {
-  name        = var.name_prefix != null ? "${var.name_prefix}_resource_compliance" : "resource_compliance"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_resource_compliance" : "resource_compliance"
   description = "Report for showing whether resources are compliant with the framework"
 
   report_delivery_channel {
@@ -55,7 +55,7 @@ resource "aws_backup_report_plan" "resource_compliance" {
 
 resource "aws_backup_report_plan" "copy_jobs" {
   count       = var.backup_copy_vault_arn != "" && var.backup_copy_vault_account_id != "" ? 1 : 0
-  name        = var.name_prefix != null ? "${var.name_prefix}_copy_jobs" : "copy_jobs"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_copy_jobs" : "copy_jobs"
   description = "Report for showing whether copies ran successfully in the last 24 hours"
 
   report_delivery_channel {

--- a/modules/aws-backup-source/backup_restore_testing.tf
+++ b/modules/aws-backup-source/backup_restore_testing.tf
@@ -1,5 +1,5 @@
 resource "awscc_backup_restore_testing_plan" "backup_restore_testing_plan" {
-  restore_testing_plan_name = var.name_prefix != null ? "${var.name_prefix}_backup_restore_testing_plan" : "backup_restore_testing_plan"
+  restore_testing_plan_name = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_restore_testing_plan" : "backup_restore_testing_plan"
   schedule_expression       = var.restore_testing_plan_scheduled_expression
   start_window_hours        = var.restore_testing_plan_start_window
   recovery_point_selection = {

--- a/modules/aws-backup-source/iam.tf
+++ b/modules/aws-backup-source/iam.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "backup" {
-  name                 = "${var.project_name}BackupRole"
+  name                 = "${var.include_environment_in_resource_names ? "${var.project_name}-${var.environment_name}" : var.project_name}BackupRole"
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = length(var.iam_role_permissions_boundary) > 0 ? var.iam_role_permissions_boundary : null
 }

--- a/modules/aws-backup-source/kms.tf
+++ b/modules/aws-backup-source/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "aws_backup_key" {
 }
 
 resource "aws_kms_alias" "backup_key" {
-  name          = var.name_prefix != null ? "alias/${var.name_prefix}/backup-key" : "alias/${var.environment_name}/backup-key"
+  name          = var.name_prefix != null ? "alias/${var.include_environment_in_resource_names ? "${local.resource_name_prefix}" : var.name_prefix}/backup-key" : "alias/${var.environment_name}/backup-key"
   target_key_id = aws_kms_key.aws_backup_key.key_id
 }
 

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_name_prefix                             = var.name_prefix != null ? var.name_prefix : "${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}-backup"
+  resource_name_prefix                             = var.name_prefix != null ? (var.include_environment_in_resource_names ? "${var.name_prefix}-${var.environment_name}" : var.name_prefix) : (var.include_environment_in_resource_names ? "${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}-${var.environment_name}-backup" : "${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}-backup")
   selection_tag_value_null_checked                 = (var.backup_plan_config.selection_tag_value == null) ? "True" : var.backup_plan_config.selection_tag_value
   selection_tag_value_dynamodb_null_checked        = (var.backup_plan_config_dynamodb.selection_tag_value == null) ? "True" : var.backup_plan_config_dynamodb.selection_tag_value
   selection_tags_null_checked                      = (var.backup_plan_config.selection_tags == null) ? [{ "key" : var.backup_plan_config.selection_tag, "value" : local.selection_tag_value_null_checked }] : var.backup_plan_config.selection_tags

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -520,3 +520,9 @@ variable "lambda_restore_to_s3_max_wait_minutes" {
   type        = number
   default     = 5
 }
+
+variable "include_environment_in_resource_names" {
+  description = "Should the environment name be included in resource names. Required for 'all resources in the same account'"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
If we're going to be able to have all resources for multiple environments in one account (PR pending), we must make sure that all resources have the environment name in them, so they can be separated.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
