### PR TITLE
Allow creating resources for multiple environments in the same account.

### DIFF
--- a/modules/aws-backup-source/backup_framework.tf
+++ b/modules/aws-backup-source/backup_framework.tf
@@ -1,4 +1,11 @@
+data "aws_backup_framework" "main" {
+  count = var.backup_plan_config.enable && var.resources_in_same_account != "" ? 1 : 0
+  name  = replace("${var.name_prefix}-${var.resources_in_same_account}-framework", "-", "_")
+}
+
 resource "aws_backup_framework" "main" {
+  count = var.backup_plan_config.enable && var.resources_in_same_account == "" ? 1 : 0
+
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-framework", "-", "_")
   description = "${var.project_name} Backup Framework"
@@ -131,8 +138,14 @@ resource "aws_backup_framework" "main" {
   }
 }
 
+data "aws_backup_framework" "dynamodb" {
+  count = var.backup_plan_config_dynamodb.enable && var.resources_in_same_account != "" ? 1 : 0
+  name  = replace("${var.name_prefix}-${var.resources_in_same_account}-dynamodb-framework", "-", "_")
+}
+
 resource "aws_backup_framework" "dynamodb" {
-  count = var.backup_plan_config_dynamodb.enable ? 1 : 0
+  count = var.backup_plan_config_dynamodb.enable && var.resources_in_same_account == "" ? 1 : 0
+
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-dynamodb-framework", "-", "_")
   description = "${var.project_name} DynamoDB Backup Framework"
@@ -172,8 +185,14 @@ resource "aws_backup_framework" "dynamodb" {
   }
 }
 
+data "aws_backup_framework" "ebsvol" {
+  count = var.backup_plan_config_ebsvol.enable && var.resources_in_same_account != "" ? 1 : 0
+  name  = replace("${var.name_prefix}-${var.resources_in_same_account}-ebsvol-framework", "-", "_")
+}
+
 resource "aws_backup_framework" "ebsvol" {
-  count = var.backup_plan_config_ebsvol.enable ? 1 : 0
+  count = var.backup_plan_config_ebsvol.enable && var.resources_in_same_account == "" ? 1 : 0
+
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-ebsvol-framework", "-", "_")
   description = "${var.project_name} EBS Backup Framework"
@@ -213,8 +232,14 @@ resource "aws_backup_framework" "ebsvol" {
   }
 }
 
+data "aws_backup_framework" "aurora" {
+  count = var.backup_plan_config_aurora.enable && var.resources_in_same_account != "" ? 1 : 0
+  name  = replace("${var.name_prefix}-${var.resources_in_same_account}-aurora-framework", "-", "_")
+}
+
 resource "aws_backup_framework" "aurora" {
-  count = var.backup_plan_config_aurora.enable ? 1 : 0
+  count = var.backup_plan_config_aurora.enable && var.resources_in_same_account == "" ? 1 : 0
+
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-aurora-framework", "-", "_")
   description = "${var.project_name} Aurora Backup Framework"
@@ -253,8 +278,14 @@ resource "aws_backup_framework" "aurora" {
   }
 }
 
+data "aws_backup_framework" "parameter_store" {
+  count = var.backup_plan_config_parameter_store.enable && var.resources_in_same_account != "" ? 1 : 0
+  name  = replace("${var.name_prefix}-${var.resources_in_same_account}-parameter-store-framework", "-", "_")
+}
+
 resource "aws_backup_framework" "parameter_store" {
-  count = var.backup_plan_config_parameter_store.enable ? 1 : 0
+  count = var.backup_plan_config_parameter_store.enable && var.resources_in_same_account == "" ? 1 : 0
+
   # must be underscores instead of dashes
   name        = replace("${local.resource_name_prefix}-parameter-store-framework", "-", "_")
   description = "${var.project_name} Parameter Store Backup Framework"

--- a/modules/aws-backup-source/backup_notification.tf
+++ b/modules/aws-backup-source/backup_notification.tf
@@ -1,6 +1,6 @@
 resource "aws_backup_vault_notifications" "backup_notification" {
-  count             = var.notifications_target_email_address != "" ? 1 : 0
-  backup_vault_name = aws_backup_vault.main.name
+  count             = var.notifications_target_email_address != "" && var.resources_in_same_account == "" ? 1 : 0
+  backup_vault_name = aws_backup_vault.main[0].name
   sns_topic_arn     = aws_sns_topic.backup[0].arn
   backup_vault_events = [
     "BACKUP_JOB_COMPLETED",

--- a/modules/aws-backup-source/backup_plan.tf
+++ b/modules/aws-backup-source/backup_plan.tf
@@ -104,7 +104,7 @@ resource "aws_backup_plan" "aurora" {
         backup_rule_name = rule.value.name
       }
       rule_name         = rule.value.name
-      target_vault_name = aws_backup_vault.main.name
+      target_vault_name = aws_backup_vault.main[0].name
       schedule          = rule.value.schedule
       lifecycle {
         delete_after       = rule.value.lifecycle.delete_after != null ? rule.value.lifecycle.delete_after : null

--- a/modules/aws-backup-source/backup_plan.tf
+++ b/modules/aws-backup-source/backup_plan.tf
@@ -1,5 +1,6 @@
 resource "aws_backup_plan" "default" {
-  name = "${local.resource_name_prefix}-plan"
+  count = var.backup_plan_config.enable && var.resources_in_same_account == "" ? 1 : 0
+  name  = "${local.resource_name_prefix}-plan"
 
   dynamic "rule" {
     for_each = var.backup_plan_config.rules
@@ -31,7 +32,7 @@ resource "aws_backup_plan" "default" {
 
 # this backup plan shouldn't include a continous backup rule as it isn't supported for DynamoDB
 resource "aws_backup_plan" "dynamodb" {
-  count = var.backup_plan_config_dynamodb.enable ? 1 : 0
+  count = var.backup_plan_config_dynamodb.enable && var.resources_in_same_account == "" ? 1 : 0
   name  = "${local.resource_name_prefix}-dynamodb-plan"
 
   dynamic "rule" {
@@ -62,7 +63,7 @@ resource "aws_backup_plan" "dynamodb" {
 }
 
 resource "aws_backup_plan" "ebsvol" {
-  count = var.backup_plan_config_ebsvol.enable ? 1 : 0
+  count = var.backup_plan_config_ebsvol.enable && var.resources_in_same_account == "" ? 1 : 0
   name  = "${local.resource_name_prefix}-ebsvol-plan"
 
   dynamic "rule" {
@@ -93,7 +94,7 @@ resource "aws_backup_plan" "ebsvol" {
 
 # this backup plan shouldn't include a continous backup rule as it isn't supported for Aurora
 resource "aws_backup_plan" "aurora" {
-  count = var.backup_plan_config_aurora.enable ? 1 : 0
+  count = var.backup_plan_config_aurora.enable && var.resources_in_same_account == "" ? 1 : 0
   name  = "${local.resource_name_prefix}-aurora-plan"
 
   dynamic "rule" {
@@ -122,9 +123,8 @@ resource "aws_backup_plan" "aurora" {
   }
 }
 
-
 resource "aws_backup_plan" "parameter_store" {
-  count = var.backup_plan_config_parameter_store.enable ? 1 : 0
+  count = var.backup_plan_config_parameter_store.enable && var.resources_in_same_account == "" ? 1 : 0
   name  = "${local.resource_name_prefix}-ps-plan"
 
   dynamic "rule" {
@@ -157,6 +157,8 @@ resource "aws_backup_plan" "parameter_store" {
 
 
 resource "aws_backup_selection" "default" {
+  count = var.backup_plan_config.enable && var.resources_in_same_account == "" ? 1 : 0
+
   iam_role_arn = aws_iam_role.backup.arn
   name         = "${local.resource_name_prefix}-selection"
   plan_id      = aws_backup_plan.default.id
@@ -178,7 +180,7 @@ resource "aws_backup_selection" "default" {
 }
 
 resource "aws_backup_selection" "dynamodb" {
-  count        = var.backup_plan_config_dynamodb.enable ? 1 : 0
+  count        = var.backup_plan_config_dynamodb.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn = aws_iam_role.backup.arn
   name         = "${local.resource_name_prefix}-dynamodb-selection"
   plan_id      = aws_backup_plan.dynamodb[0].id
@@ -200,7 +202,7 @@ resource "aws_backup_selection" "dynamodb" {
 }
 
 resource "aws_backup_selection" "ebsvol" {
-  count        = var.backup_plan_config_ebsvol.enable ? 1 : 0
+  count        = var.backup_plan_config_ebsvol.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn = aws_iam_role.backup.arn
   name         = "${local.resource_name_prefix}-ebsvol-selection"
   plan_id      = aws_backup_plan.ebsvol[0].id
@@ -222,7 +224,7 @@ resource "aws_backup_selection" "ebsvol" {
 }
 
 resource "aws_backup_selection" "aurora" {
-  count        = var.backup_plan_config_aurora.enable ? 1 : 0
+  count        = var.backup_plan_config_aurora.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn = aws_iam_role.backup.arn
   name         = "${local.resource_name_prefix}-aurora-selection"
   plan_id      = aws_backup_plan.aurora[0].id
@@ -235,7 +237,7 @@ resource "aws_backup_selection" "aurora" {
 }
 
 resource "aws_backup_selection" "parameter_store" {
-  count        = var.backup_plan_config_parameter_store.enable ? 1 : 0
+  count        = var.backup_plan_config_parameter_store.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn = aws_iam_role.backup.arn
   name         = "${local.resource_name_prefix}-ps-selection"
   plan_id      = aws_backup_plan.parameter_store[0].id

--- a/modules/aws-backup-source/backup_report_plan.tf
+++ b/modules/aws-backup-source/backup_report_plan.tf
@@ -1,6 +1,6 @@
 # Create the reports
 resource "aws_backup_report_plan" "backup_jobs" {
-  name        = var.name_prefix != null ? "${var.name_prefix}_backup_jobs" : "backup_jobs"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_jobs" : "backup_jobs"
   description = "Report for showing whether backups ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -18,7 +18,7 @@ resource "aws_backup_report_plan" "backup_jobs" {
 
 # Create the restore testing completion reports
 resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
-  name        = var.name_prefix != null ? "${var.name_prefix}_backup_restore_testing_jobs" : "backup_restore_testing_jobs"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_restore_testing_jobs" : "backup_restore_testing_jobs"
   description = "Report for showing whether backup restore test ran successfully in the last 24 hours"
 
   report_delivery_channel {
@@ -35,7 +35,7 @@ resource "aws_backup_report_plan" "backup_restore_testing_jobs" {
 }
 
 resource "aws_backup_report_plan" "resource_compliance" {
-  name        = var.name_prefix != null ? "${var.name_prefix}_resource_compliance" : "resource_compliance"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_resource_compliance" : "resource_compliance"
   description = "Report for showing whether resources are compliant with the framework"
 
   report_delivery_channel {
@@ -55,7 +55,7 @@ resource "aws_backup_report_plan" "resource_compliance" {
 
 resource "aws_backup_report_plan" "copy_jobs" {
   count       = var.backup_copy_vault_arn != "" && var.backup_copy_vault_account_id != "" ? 1 : 0
-  name        = var.name_prefix != null ? "${var.name_prefix}_copy_jobs" : "copy_jobs"
+  name        = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_copy_jobs" : "copy_jobs"
   description = "Report for showing whether copies ran successfully in the last 24 hours"
 
   report_delivery_channel {

--- a/modules/aws-backup-source/backup_restore_testing.tf
+++ b/modules/aws-backup-source/backup_restore_testing.tf
@@ -1,5 +1,5 @@
 resource "awscc_backup_restore_testing_plan" "backup_restore_testing_plan" {
-  restore_testing_plan_name = var.name_prefix != null ? "${var.name_prefix}_backup_restore_testing_plan" : "backup_restore_testing_plan"
+  restore_testing_plan_name = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_restore_testing_plan" : "backup_restore_testing_plan"
   schedule_expression       = var.restore_testing_plan_scheduled_expression
   start_window_hours        = var.restore_testing_plan_start_window
   recovery_point_selection = {

--- a/modules/aws-backup-source/backup_restore_testing.tf
+++ b/modules/aws-backup-source/backup_restore_testing.tf
@@ -1,20 +1,21 @@
 resource "awscc_backup_restore_testing_plan" "backup_restore_testing_plan" {
+  count = (var.backup_plan_config.enable || var.backup_plan_config_dynamodb.enable || var.backup_plan_config_ebsvol.enable || var.backup_plan_config_aurora.enable) && var.resources_in_same_account == "" ? 1 : 0
   restore_testing_plan_name = var.name_prefix != null ? "${replace(local.resource_name_prefix, "-", "_")}_backup_restore_testing_plan" : "backup_restore_testing_plan"
   schedule_expression       = var.restore_testing_plan_scheduled_expression
   start_window_hours        = var.restore_testing_plan_start_window
   recovery_point_selection = {
     algorithm             = var.restore_testing_plan_algorithm
-    include_vaults        = [aws_backup_vault.main.arn]
+    include_vaults        = [aws_backup_vault.main[0].arn]
     recovery_point_types  = var.restore_testing_plan_recovery_point_types
     selection_window_days = var.restore_testing_plan_selection_window_days
   }
 }
 
 resource "awscc_backup_restore_testing_selection" "backup_restore_testing_selection_dynamodb" {
-  count                          = var.backup_plan_config_dynamodb.enable ? 1 : 0
+  count                          = var.backup_plan_config_dynamodb.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn                   = aws_iam_role.backup.arn
   protected_resource_type        = "DynamoDB"
-  restore_testing_plan_name      = awscc_backup_restore_testing_plan.backup_restore_testing_plan.restore_testing_plan_name
+  restore_testing_plan_name      = awscc_backup_restore_testing_plan.backup_restore_testing_plan[0].restore_testing_plan_name
   restore_testing_selection_name = "backup_restore_testing_selection_dynamodb"
   protected_resource_arns        = ["*"]
   protected_resource_conditions = {
@@ -27,10 +28,10 @@ resource "awscc_backup_restore_testing_selection" "backup_restore_testing_select
 
 
 resource "awscc_backup_restore_testing_selection" "backup_restore_testing_selection_ebsvol" {
-  count                          = var.backup_plan_config_ebsvol.enable ? 1 : 0
+  count                          = var.backup_plan_config_ebsvol.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn                   = aws_iam_role.backup.arn
   protected_resource_type        = "EBS"
-  restore_testing_plan_name      = awscc_backup_restore_testing_plan.backup_restore_testing_plan.restore_testing_plan_name
+  restore_testing_plan_name      = awscc_backup_restore_testing_plan.backup_restore_testing_plan[0].restore_testing_plan_name
   restore_testing_selection_name = "backup_restore_testing_selection_ebsvol"
   protected_resource_arns        = ["*"]
   protected_resource_conditions = {
@@ -42,10 +43,10 @@ resource "awscc_backup_restore_testing_selection" "backup_restore_testing_select
 }
 
 resource "awscc_backup_restore_testing_selection" "backup_restore_testing_selection_aurora" {
-  count                          = var.backup_plan_config_aurora.enable ? 1 : 0
+  count                          = var.backup_plan_config_aurora.enable && var.resources_in_same_account == "" ? 1 : 0
   iam_role_arn                   = aws_iam_role.backup.arn
   protected_resource_type        = "Aurora"
-  restore_testing_plan_name      = awscc_backup_restore_testing_plan.backup_restore_testing_plan.restore_testing_plan_name
+  restore_testing_plan_name      = awscc_backup_restore_testing_plan.backup_restore_testing_plan[0].restore_testing_plan_name
   restore_testing_selection_name = "backup_restore_testing_selection_aurora"
   protected_resource_arns        = ["*"]
   protected_resource_conditions = {
@@ -55,4 +56,11 @@ resource "awscc_backup_restore_testing_selection" "backup_restore_testing_select
     }]
   }
   restore_metadata_overrides = local.aurora_overrides
+}
+
+# -----
+
+moved {
+  from = awscc_backup_restore_testing_plan.backup_restore_testing_plan
+  to   = awscc_backup_restore_testing_plan.backup_restore_testing_plan[0]
 }

--- a/modules/aws-backup-source/backup_vault.tf
+++ b/modules/aws-backup-source/backup_vault.tf
@@ -1,4 +1,11 @@
 resource "aws_backup_vault" "main" {
+  count = var.resources_in_same_account == "" ? 1 : 0
+
   name        = "${local.resource_name_prefix}-vault"
   kms_key_arn = aws_kms_key.aws_backup_key.arn
+}
+
+moved {
+  from = aws_backup_vault.main
+  to   = aws_backup_vault.main[0]
 }

--- a/modules/aws-backup-source/backup_vault_policy.tf
+++ b/modules/aws-backup-source/backup_vault_policy.tf
@@ -1,10 +1,12 @@
 resource "aws_backup_vault_policy" "vault_policy" {
-  backup_vault_name = aws_backup_vault.main.name
-  policy            = data.aws_iam_policy_document.vault_policy.json
+  count = var.resources_in_same_account == "" ? 1 : 0
+
+  backup_vault_name = aws_backup_vault.main[0].name
+  policy            = data.aws_iam_policy_document.vault_policy[0].json
 }
 
 data "aws_iam_policy_document" "vault_policy" {
-
+  count = var.resources_in_same_account == "" ? 1 : 0
 
   statement {
     sid    = "DenyApartFromTerraform"
@@ -44,4 +46,14 @@ data "aws_iam_policy_document" "vault_policy" {
       }
     }
   }
+}
+
+moved {
+  from = aws_backup_vault_policy.vault_policy
+  to   = aws_backup_vault_policy.vault_policy[0]
+}
+
+moved {
+  from = data.aws_iam_policy_document.vault_policy
+  to   = data.aws_iam_policy_document.vault_policy[0]
 }

--- a/modules/aws-backup-source/iam.tf
+++ b/modules/aws-backup-source/iam.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "backup" {
-  name                 = "${var.project_name}BackupRole"
+  name                 = "${var.include_environment_in_resource_names ? "${var.project_name}-${var.environment_name}" : var.project_name}BackupRole"
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = length(var.iam_role_permissions_boundary) > 0 ? var.iam_role_permissions_boundary : null
 }

--- a/modules/aws-backup-source/kms.tf
+++ b/modules/aws-backup-source/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "aws_backup_key" {
 }
 
 resource "aws_kms_alias" "backup_key" {
-  name          = var.name_prefix != null ? "alias/${var.name_prefix}/backup-key" : "alias/${var.environment_name}/backup-key"
+  name          = var.name_prefix != null ? "alias/${var.include_environment_in_resource_names ? "${local.resource_name_prefix}" : var.name_prefix}/backup-key" : "alias/${var.environment_name}/backup-key"
   target_key_id = aws_kms_key.aws_backup_key.key_id
 }
 

--- a/modules/aws-backup-source/lambda_copy_recovery_point.tf
+++ b/modules/aws-backup-source/lambda_copy_recovery_point.tf
@@ -1,12 +1,12 @@
 data "archive_file" "lambda_copy_recovery_point_zip" {
-  count       = var.lambda_copy_recovery_point_enable ? 1 : 0
+  count       = var.lambda_copy_recovery_point_enable && var.resources_in_same_account == "" ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/resources/copy-recovery-point/"
   output_path = "${path.module}/.terraform/archive_files/lambda_copy_recovery_point.zip"
 }
 
 resource "aws_iam_role" "iam_for_lambda_copy_recovery_point" {
-  count = var.lambda_copy_recovery_point_enable ? 1 : 0
+  count = var.lambda_copy_recovery_point_enable && var.resources_in_same_account == "" ? 1 : 0
   name  = "${local.resource_name_prefix}-lambda-copy-recovery-point-role"
 
   assume_role_policy = jsonencode({
@@ -20,7 +20,7 @@ resource "aws_iam_role" "iam_for_lambda_copy_recovery_point" {
 }
 
 resource "aws_iam_policy" "iam_policy_for_lambda_copy_recovery_point" {
-  count = var.lambda_copy_recovery_point_enable ? 1 : 0
+  count = var.lambda_copy_recovery_point_enable && var.resources_in_same_account == "" ? 1 : 0
   name  = "${local.resource_name_prefix}-lambda-copy-recovery-point-policy"
 
   policy = jsonencode({
@@ -54,13 +54,13 @@ resource "aws_iam_policy" "iam_policy_for_lambda_copy_recovery_point" {
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_copy_recovery_point_policy_attach" {
-  count      = var.lambda_copy_recovery_point_enable ? 1 : 0
+  count      = var.lambda_copy_recovery_point_enable && var.resources_in_same_account == "" ? 1 : 0
   role       = aws_iam_role.iam_for_lambda_copy_recovery_point[0].name
   policy_arn = aws_iam_policy.iam_policy_for_lambda_copy_recovery_point[0].arn
 }
 
 resource "aws_lambda_function" "lambda_copy_recovery_point" {
-  count            = var.lambda_copy_recovery_point_enable ? 1 : 0
+  count            = var.lambda_copy_recovery_point_enable && var.resources_in_same_account == "" ? 1 : 0
   function_name    = "${local.resource_name_prefix}_lambda-copy-recovery-point"
   role             = aws_iam_role.iam_for_lambda_copy_recovery_point[0].arn
   handler          = "lambda_function.lambda_handler"
@@ -74,7 +74,7 @@ resource "aws_lambda_function" "lambda_copy_recovery_point" {
       POLL_INTERVAL_SECONDS = var.lambda_copy_recovery_point_poll_interval_seconds
       MAX_WAIT_MINUTES      = var.lambda_copy_recovery_point_max_wait_minutes
       DESTINATION_VAULT_ARN = var.lambda_copy_recovery_point_destination_vault_arn != "" ? var.lambda_copy_recovery_point_destination_vault_arn : var.backup_copy_vault_arn
-      SOURCE_VAULT_ARN      = var.lambda_copy_recovery_point_source_vault_arn != "" ? var.lambda_copy_recovery_point_source_vault_arn : aws_backup_vault.main.arn
+      SOURCE_VAULT_ARN      = var.lambda_copy_recovery_point_source_vault_arn != "" ? var.lambda_copy_recovery_point_source_vault_arn : aws_backup_vault.main[0].arn
       ASSUME_ROLE_ARN       = var.lambda_copy_recovery_point_assume_role_arn
     }
   }

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_name_prefix                             = var.name_prefix != null ? var.name_prefix : "${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}-backup"
+  resource_name_prefix                             = var.name_prefix != null ? (var.include_environment_in_resource_names ? "${var.name_prefix}-${var.environment_name}" : var.name_prefix) : (var.include_environment_in_resource_names ? "${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}-${var.environment_name}-backup" : "${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}-backup")
   selection_tag_value_null_checked                 = (var.backup_plan_config.selection_tag_value == null) ? "True" : var.backup_plan_config.selection_tag_value
   selection_tag_value_dynamodb_null_checked        = (var.backup_plan_config_dynamodb.selection_tag_value == null) ? "True" : var.backup_plan_config_dynamodb.selection_tag_value
   selection_tags_null_checked                      = (var.backup_plan_config.selection_tags == null) ? [{ "key" : var.backup_plan_config.selection_tag, "value" : local.selection_tag_value_null_checked }] : var.backup_plan_config.selection_tags

--- a/modules/aws-backup-source/locals.tf
+++ b/modules/aws-backup-source/locals.tf
@@ -12,7 +12,7 @@ locals {
     [aws_backup_framework.main.arn],
     var.backup_plan_config_ebsvol.enable ? [aws_backup_framework.ebsvol[0].arn] : [],
     var.backup_plan_config_dynamodb.enable ? [aws_backup_framework.dynamodb[0].arn] : [],
-    var.backup_plan_config_aurora.enable ? [aws_backup_framework.aurora[0].arn] : [],
+    var.backup_plan_config_aurora.enable ? [var.resources_in_same_account == "" ? aws_backup_framework.aurora[0].arn : data.aws_backup_framework.aurora[0].arn] : [],
     var.backup_plan_config_parameter_store.enable ? [aws_backup_framework.parameter_store[0].arn] : []
 
   ))

--- a/modules/aws-backup-source/outputs.tf
+++ b/modules/aws-backup-source/outputs.tf
@@ -4,11 +4,11 @@ output "backup_role_arn" {
 }
 
 output "backup_vault_arn" {
-  value       = aws_backup_vault.main.arn
+  value       =  var.resources_in_same_account == "" ? aws_backup_vault.main[0].arn : null
   description = "ARN of the of the vault"
 }
 
 output "backup_vault_name" {
-  value       = aws_backup_vault.main.name
+  value       = var.resources_in_same_account == "" ? aws_backup_vault.main[0].name : null
   description = "Name of the of the vault"
 }

--- a/modules/aws-backup-source/sns.tf
+++ b/modules/aws-backup-source/sns.tf
@@ -1,11 +1,12 @@
 resource "aws_sns_topic" "backup" {
-  count             = var.notifications_target_email_address != "" ? 1 : 0
+  count             = var.notifications_target_email_address != "" && var.resources_in_same_account == "" ? 1 : 0
   name              = "${local.resource_name_prefix}-notifications"
   kms_master_key_id = var.bootstrap_kms_key_arn
-  policy            = data.aws_iam_policy_document.allow_backup_to_sns.json
+  policy            = data.aws_iam_policy_document.allow_backup_to_sns[0].json
 }
 
 data "aws_iam_policy_document" "allow_backup_to_sns" {
+  count     = var.notifications_target_email_address != "" && var.resources_in_same_account == "" ? 1 : 0
   policy_id = "backup"
 
   statement {
@@ -27,9 +28,16 @@ data "aws_iam_policy_document" "allow_backup_to_sns" {
 }
 
 resource "aws_sns_topic_subscription" "aws_backup_notifications_email_target" {
-  count         = var.notifications_target_email_address != "" ? 1 : 0
+  count         = var.notifications_target_email_address != "" && var.resources_in_same_account == "" ? 1 : 0
   topic_arn     = aws_sns_topic.backup[0].arn
   protocol      = "email"
   endpoint      = var.notifications_target_email_address
   filter_policy = jsonencode({ "State" : [{ "anything-but" : "COMPLETED" }] })
+}
+
+# -----
+
+moved {
+  from = data.aws_iam_policy_document.allow_backup_to_sns
+  to   = data.aws_iam_policy_document.allow_backup_to_sns[0]
 }

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -520,3 +520,9 @@ variable "lambda_restore_to_s3_max_wait_minutes" {
   type        = number
   default     = 5
 }
+
+variable "include_environment_in_resource_names" {
+  description = "Should the environment name be included in resource names. Required for 'all resources in the same account'"
+  type        = bool
+  default     = false
+}

--- a/modules/aws-backup-source/variables.tf
+++ b/modules/aws-backup-source/variables.tf
@@ -526,3 +526,13 @@ variable "include_environment_in_resource_names" {
   type        = bool
   default     = false
 }
+
+# Plans etc are _account_ specific, not _environment_ specific, so we only want to create some resources
+# once. As in, when this is `""` (empty string). For additional envs in the account, set this to the environment
+# where the "base" resources are (for example `dev`).
+# NOTE: Require `include_environment_in_resource_names` set to `true` for this to work!
+variable "resources_in_same_account" {
+  description = "Should all resources be created in the same account. Set to 'true' if base resources already exists in the account, and they should be reused."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
If there's multiple environment builds in the same account (such as `dev`, `test`, `non-prod` etc), we can't create ALL resources in that account.

Plans and frameworks are _account_ specific, not _environment_ specific.
As in, a plan will have a selection (such as "backup everything with the tag `xyz` set to `abc`"). So having separate plans for each env doesn make any sense, they will be identical and backup the same resources.

So introduce a new variable `resources_in_same_account` which should be set to the account where *everything* (the "account specific" resources) are created.

Depends on: `include_environment_in_resource_names = true`.
Depends on: https://github.com/NHSDigital/terraform-aws-backup/pull/118

**NOTE**: In this PR, the #118 PR is included, because it builds on that! That PR needs to be merged before this, which should then be rebased to remove that first commit, before this PR can be merged.
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
